### PR TITLE
[FEAT] 수면 데이터 관련 API 구현 (#5)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	implementation 'org.springframework.security:spring-security-crypto'
 	//메일
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
+	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.projectlombok:lombok'
@@ -45,9 +46,12 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	//swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
-	//캐싱
-	implementation 'org.springframework.boot:spring-boot-starter-cache'
-	implementation 'com.github.ben-manes.caffeine:caffeine'
+	//aws
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+	//csv
+	implementation 'com.opencsv:opencsv:5.9'
+	//gpt
+	implementation 'io.github.flashvayne:chatgpt-spring-boot-starter:1.0.4'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/snorlaexes/raem/domain/sleep/Enums/BadAwakeReason.java
+++ b/src/main/java/com/snorlaexes/raem/domain/sleep/Enums/BadAwakeReason.java
@@ -1,0 +1,5 @@
+package com.snorlaexes.raem.domain.sleep.Enums;
+
+public enum BadAwakeReason {
+    COFFEE, EXERCISE, STRESS, ALCOHOL
+}

--- a/src/main/java/com/snorlaexes/raem/domain/sleep/Enums/SleepStage.java
+++ b/src/main/java/com/snorlaexes/raem/domain/sleep/Enums/SleepStage.java
@@ -1,0 +1,5 @@
+package com.snorlaexes.raem.domain.sleep.Enums;
+
+public enum SleepStage {
+    AWAKE, REM, DEEP
+}

--- a/src/main/java/com/snorlaexes/raem/domain/sleep/SleepController.java
+++ b/src/main/java/com/snorlaexes/raem/domain/sleep/SleepController.java
@@ -1,0 +1,40 @@
+package com.snorlaexes.raem.domain.sleep;
+
+import com.snorlaexes.raem.domain.sleep.entities.SleepDataEntity;
+import com.snorlaexes.raem.domain.sleep.entities.SleepDataUrlEntity;
+import com.snorlaexes.raem.global.apiPayload.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDate;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/sleep")
+public class SleepController {
+    private final SleepService sleepService;
+    @PostMapping(value = "/data", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_OCTET_STREAM_VALUE}, params = "type=file")
+    public ApiResponse<SleepResDTO.SaveDataResponseDTO> saveFile(@RequestPart LocalDate sleptAt, @RequestPart MultipartFile file, @AuthenticationPrincipal String userId) {
+        SleepDataUrlEntity sleepDataUrlEntity = sleepService.sendS3AndSave(userId, sleptAt, file);
+        return ApiResponse.onSuccess(SleepResDTO.SaveDataResponseDTO.saveDataResultDTO(sleepDataUrlEntity));
+    }
+
+    @PostMapping(value = "/data", params = "type=json")
+    public ApiResponse<SleepResDTO.SaveDataResponseDTO> saveData(@RequestBody SleepReqDTO.SaveDataDTO req, @AuthenticationPrincipal String userId) {
+        SleepDataEntity sleepData = sleepService.organizeSleepData(userId, req);
+        return ApiResponse.onSuccess(SleepResDTO.SaveDataResponseDTO.organizeDataResultDTO(sleepData));
+    }
+
+    @PatchMapping("/data")
+    public ApiResponse<SleepResDTO.SaveReasonResponseDTO> saveBadReason(@RequestBody SleepReqDTO.SaveReasonDTO req) {
+        return ApiResponse.onSuccess(SleepResDTO.SaveReasonResponseDTO.saveReasonResultDTO(sleepService.saveReasonService(req)));
+    }
+
+    @GetMapping("/data")
+    public ApiResponse<SleepResDTO.GetDataUrlResponseDTO> getDataUrl(@RequestBody SleepReqDTO.GetDataUrlDTO req) {
+        return ApiResponse.onSuccess(SleepResDTO.GetDataUrlResponseDTO.getDataUrlResponseDTO(sleepService.getDataUrlService(req)));
+    }
+}

--- a/src/main/java/com/snorlaexes/raem/domain/sleep/SleepReqDTO.java
+++ b/src/main/java/com/snorlaexes/raem/domain/sleep/SleepReqDTO.java
@@ -1,0 +1,47 @@
+package com.snorlaexes.raem.domain.sleep;
+
+import com.snorlaexes.raem.domain.sleep.entities.InBedEntity;
+import com.snorlaexes.raem.domain.sleep.entities.SleepDataChildEntity;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import org.springframework.lang.Nullable;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+public class SleepReqDTO {
+    @Getter
+    public static class SaveDataDTO {
+        @NotNull
+        LocalDate sleptAt;
+        @Nullable
+        Integer score;
+        @Nullable
+        LocalTime setTime;
+        @Nullable
+        LocalTime awakeAt;
+        @Nullable
+        TotalSleepDataChild totalSleepData;
+    }
+
+    @Getter
+    public static class TotalSleepDataChild {
+        List<InBedEntity> inBed;
+        List<SleepDataChildEntity> sleepData;
+    }
+
+    @Getter
+    public static class SaveReasonDTO {
+        @NotNull
+        String sleepDataId;
+        @NotNull
+        String reason;
+    }
+
+    @Getter
+    public static class GetDataUrlDTO {
+        @NotNull
+        String dataId;
+    }
+}

--- a/src/main/java/com/snorlaexes/raem/domain/sleep/SleepResDTO.java
+++ b/src/main/java/com/snorlaexes/raem/domain/sleep/SleepResDTO.java
@@ -1,0 +1,61 @@
+package com.snorlaexes.raem.domain.sleep;
+
+import com.snorlaexes.raem.domain.sleep.entities.SleepDataEntity;
+import com.snorlaexes.raem.domain.sleep.entities.SleepDataUrlEntity;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+public class SleepResDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SaveDataResponseDTO {
+        String dataId;
+        LocalDateTime createdAt;
+
+        public static SaveDataResponseDTO saveDataResultDTO (SleepDataUrlEntity entity){
+            return SaveDataResponseDTO.builder()
+                    .dataId(entity.getId())
+                    .createdAt(entity.getCreatedAt())
+                    .build();
+        }
+
+        public static SaveDataResponseDTO organizeDataResultDTO (SleepDataEntity entity) {
+            return SaveDataResponseDTO.builder()
+                    .dataId(entity.getId())
+                    .createdAt(entity.getCreatedAt())
+                    .build();
+        }
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SaveReasonResponseDTO {
+        LocalDateTime updatedAt;
+
+        public static SaveReasonResponseDTO saveReasonResultDTO (SleepDataEntity entity){
+            return SaveReasonResponseDTO.builder()
+                    .updatedAt(entity.getUpdatedAt())
+                    .build();
+        }
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetDataUrlResponseDTO {
+        String url;
+
+        public static GetDataUrlResponseDTO getDataUrlResponseDTO (SleepDataUrlEntity entity){
+            return GetDataUrlResponseDTO.builder()
+                    .url(entity.getUrl())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/snorlaexes/raem/domain/sleep/SleepService.java
+++ b/src/main/java/com/snorlaexes/raem/domain/sleep/SleepService.java
@@ -1,0 +1,130 @@
+package com.snorlaexes.raem.domain.sleep;
+
+import com.snorlaexes.raem.domain.sleep.Enums.BadAwakeReason;
+import com.snorlaexes.raem.domain.sleep.entities.*;
+import com.snorlaexes.raem.domain.sleep.repository.SleepDataRepository;
+import com.snorlaexes.raem.domain.sleep.repository.SleepDataUrlRepository;
+import com.snorlaexes.raem.domain.user.UserEntity;
+import com.snorlaexes.raem.domain.user.UserRepository;
+import com.snorlaexes.raem.global.apiPayload.code.status.ErrorStatus;
+import com.snorlaexes.raem.global.apiPayload.exception.ExceptionHandler;
+import com.snorlaexes.raem.global.aws.s3.AmazonS3Manager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.*;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class SleepService {
+    private final SleepDataUrlRepository sleepDataUrlRepository;
+    private final UserRepository userRepository;
+    private final SleepDataRepository sleepDataRepository;
+    private final AmazonS3Manager s3Manager;
+
+    @Transactional
+    public SleepDataUrlEntity sendS3AndSave(String userId, LocalDate sleptAt, MultipartFile file) {
+        UserEntity user = userRepository.findById(userId)
+                .orElseThrow(() -> new ExceptionHandler(ErrorStatus._USER_NOT_FOUND));
+
+        // 확장자 검사
+        assert file != null;
+        String filename = file.getOriginalFilename();
+        assert filename != null;
+        if (!Objects.equals(filename.split("\\.")[1], "csv")) {
+            throw new ExceptionHandler(ErrorStatus._WRONG_EXTENSION);
+        }
+
+        // 파일 사이즈 검사
+        if (file.getSize() == 0) {
+            throw new ExceptionHandler(ErrorStatus._DATA_SIZE_TOO_SMALL);
+        }
+
+        // S3 저장 및 url 저장
+        String keyName = userId + "/" + sleptAt;
+        String s3Url = s3Manager.uploadFile(keyName, file);
+
+        SleepDataUrlEntity newEntity = SleepDataUrlEntity.builder()
+                .url(s3Url)
+                .user(user)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        return sleepDataUrlRepository.save(newEntity);
+    }
+
+    @Transactional
+    public SleepDataEntity organizeSleepData(String userId, SleepReqDTO.SaveDataDTO req) {
+        UserEntity user = userRepository.findById(userId)
+                .orElseThrow(() -> new ExceptionHandler(ErrorStatus._USER_NOT_FOUND));
+
+        SleepReqDTO.TotalSleepDataChild totalSleepData = req.getTotalSleepData();
+        List<InBedEntity> inBedList = totalSleepData.getInBed();
+        List<SleepDataChildEntity> sleepDataChildList = totalSleepData.getSleepData();
+
+        // In-Bed 누적 시간 계산
+        Duration inBedDuration = Duration.ZERO;
+        for (InBedEntity data : inBedList) {
+            inBedDuration = inBedDuration.plus(Duration.between(data.getStartTime(), data.getEndTime()));
+        }
+        String inBedTime = timeFormatter(inBedDuration);
+
+        // awake, sleep 누적 시간 계산
+        Duration awakeDuration = Duration.ZERO;
+        Duration sleepDuration = Duration.ZERO;
+        for (SleepDataChildEntity data : sleepDataChildList) {
+            if (data.getState().equals("Awake")) {
+                awakeDuration = awakeDuration.plus(Duration.between(data.getStartTime(), data.getEndTime()));
+            } else {
+                sleepDuration = sleepDuration.plus(Duration.between(data.getStartTime(), data.getEndTime()));
+            }
+        }
+        String awakeTime = timeFormatter(awakeDuration);
+        String sleepTime = timeFormatter(sleepDuration);
+
+        SleepDataEntity newSleepData = SleepDataEntity.builder()
+                .sleptAt(req.getSleptAt())
+                .score(req.getScore())
+                .awakeTime(req.getAwakeAt())
+                .timeOnBed(inBedTime)
+                .sleepTime(awakeTime)
+                .fellAsleepTime(sleepTime)
+                .user(user)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        return sleepDataRepository.save(newSleepData);
+    }
+
+    private String timeFormatter(Duration duration) {
+        long hours = duration.toHours();
+        long minutes = duration.toMinutes() % 60;
+        long seconds = duration.getSeconds() % 60;
+        return String.format("%02d:%02d:%02d", hours, minutes, seconds);
+    }
+
+    @Transactional
+    public SleepDataEntity saveReasonService(SleepReqDTO.SaveReasonDTO req) {
+        BadAwakeReason reason = BadAwakeReason.valueOf(req.getReason().toUpperCase());
+        SleepDataEntity sleepData = sleepDataRepository.findById(req.getSleepDataId())
+                .orElseThrow(() -> new ExceptionHandler(ErrorStatus._SLEEP_DATA_NOT_FOUND));
+
+        sleepData.setBadAwakeReason(reason);
+        sleepData.setUpdatedAt(LocalDateTime.now());
+
+        return sleepDataRepository.save(sleepData);
+    }
+
+    @Transactional
+    public SleepDataUrlEntity getDataUrlService(SleepReqDTO.GetDataUrlDTO req) {
+        return sleepDataUrlRepository.findById(req.getDataId())
+                .orElseThrow(() -> new ExceptionHandler(ErrorStatus._URL_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/snorlaexes/raem/domain/sleep/entities/InBedEntity.java
+++ b/src/main/java/com/snorlaexes/raem/domain/sleep/entities/InBedEntity.java
@@ -1,0 +1,11 @@
+package com.snorlaexes.raem.domain.sleep.entities;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class InBedEntity {
+    LocalDateTime startTime;
+    LocalDateTime endTime;
+}

--- a/src/main/java/com/snorlaexes/raem/domain/sleep/entities/SleepDataChildEntity.java
+++ b/src/main/java/com/snorlaexes/raem/domain/sleep/entities/SleepDataChildEntity.java
@@ -1,0 +1,12 @@
+package com.snorlaexes.raem.domain.sleep.entities;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class SleepDataChildEntity {
+    String state;
+    LocalDateTime startTime;
+    LocalDateTime endTime;
+}

--- a/src/main/java/com/snorlaexes/raem/domain/sleep/entities/SleepDataEntity.java
+++ b/src/main/java/com/snorlaexes/raem/domain/sleep/entities/SleepDataEntity.java
@@ -1,0 +1,41 @@
+package com.snorlaexes.raem.domain.sleep.entities;
+
+import com.snorlaexes.raem.domain.sleep.Enums.BadAwakeReason;
+import com.snorlaexes.raem.domain.user.UserEntity;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.mongodb.core.mapping.DBRef;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Getter
+@Setter
+@Builder
+@Document(collection = "SleepData")
+public class SleepDataEntity {
+    @Id
+    String id;
+    LocalDate sleptAt;
+    Integer score;
+    BadAwakeReason badAwakeReason;
+
+    LocalTime awakeTime;
+    String fellAsleepTime;
+    String sleepTime;
+    String timeOnBed;
+
+    @CreatedDate
+    LocalDateTime createdAt;
+    @LastModifiedDate
+    LocalDateTime updatedAt;
+
+    @DBRef
+    private UserEntity user;
+}

--- a/src/main/java/com/snorlaexes/raem/domain/sleep/entities/SleepDataUrlEntity.java
+++ b/src/main/java/com/snorlaexes/raem/domain/sleep/entities/SleepDataUrlEntity.java
@@ -1,0 +1,27 @@
+package com.snorlaexes.raem.domain.sleep.entities;
+
+import com.snorlaexes.raem.domain.user.UserEntity;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.DBRef;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@Document(collection = "SleepDataUrl")
+public class SleepDataUrlEntity {
+    @Id
+    String id;
+    String url;
+    @CreatedDate
+    LocalDateTime createdAt;
+
+    @DBRef
+    private UserEntity user;
+}

--- a/src/main/java/com/snorlaexes/raem/domain/sleep/repository/SleepDataRepository.java
+++ b/src/main/java/com/snorlaexes/raem/domain/sleep/repository/SleepDataRepository.java
@@ -1,0 +1,12 @@
+package com.snorlaexes.raem.domain.sleep.repository;
+
+import com.snorlaexes.raem.domain.sleep.entities.SleepDataEntity;
+import com.snorlaexes.raem.domain.user.UserEntity;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.Date;
+import java.util.Optional;
+
+public interface SleepDataRepository extends MongoRepository<SleepDataEntity, String> {
+    Optional<SleepDataEntity> findBySleptAtAndUser(Date date, UserEntity user);
+}

--- a/src/main/java/com/snorlaexes/raem/domain/sleep/repository/SleepDataUrlRepository.java
+++ b/src/main/java/com/snorlaexes/raem/domain/sleep/repository/SleepDataUrlRepository.java
@@ -1,0 +1,7 @@
+package com.snorlaexes.raem.domain.sleep.repository;
+
+import com.snorlaexes.raem.domain.sleep.entities.SleepDataUrlEntity;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface SleepDataUrlRepository extends MongoRepository<SleepDataUrlEntity, String> {
+}

--- a/src/main/java/com/snorlaexes/raem/domain/user/UserController.java
+++ b/src/main/java/com/snorlaexes/raem/domain/user/UserController.java
@@ -11,7 +11,7 @@ import java.util.Objects;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/user")
+@RequestMapping("/api/user")
 public class UserController {
     private final UserService userService;
 

--- a/src/main/java/com/snorlaexes/raem/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/snorlaexes/raem/global/apiPayload/code/status/ErrorStatus.java
@@ -15,6 +15,8 @@ public enum ErrorStatus implements BaseErrorCode {
     _BAD_REQUEST(HttpStatus.BAD_REQUEST,"COMMON400","잘못된 요청입니다."),
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+    _WRONG_EXTENSION(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "COMMON404", "잘못된 파일 형식입니다."),
+    _WRONG_PARAM(HttpStatus.FORBIDDEN, "COMMON405", "잘못된 파라미터입니다."),
 
     // 유저 관련 응답
     _USER_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "USER400", "사용 중인 이메일입니다."),
@@ -27,7 +29,13 @@ public enum ErrorStatus implements BaseErrorCode {
     _ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH401", "AccessToken이 만료되었습니다."),
     _AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "AUTH402", "이메일 또는 비밀번호가 틀렸습니다."),
 
+    // 이메일 관련 응답
     _UNABLE_TO_SEND_EMAIL(HttpStatus.INTERNAL_SERVER_ERROR, "EMAIL501", "이메일 전송 중 문제가 발생했습니다."),
+
+    // 수면 관련 응답
+    _DATA_SIZE_TOO_SMALL(HttpStatus.BAD_REQUEST, "SLEEP601", "데이터 사이즈가 너무 작습니다."),
+    _SLEEP_DATA_NOT_FOUND(HttpStatus.BAD_REQUEST, "SLEEP602", "수면 데이터가 없습니다."),
+    _URL_NOT_FOUND(HttpStatus.BAD_REQUEST, "SLEEP603", "수면 데이터 파일을 찾을 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/snorlaexes/raem/global/aws/s3/AmazonS3Manager.java
+++ b/src/main/java/com/snorlaexes/raem/global/aws/s3/AmazonS3Manager.java
@@ -1,0 +1,34 @@
+package com.snorlaexes.raem.global.aws.s3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.snorlaexes.raem.global.config.AmazonConfig;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AmazonS3Manager{
+
+    private final AmazonS3 amazonS3;
+
+    private final AmazonConfig amazonConfig;
+
+    public String uploadFile(String keyName, MultipartFile file){
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(file.getSize());
+        try {
+            amazonS3.putObject(new PutObjectRequest(amazonConfig.getBucket(), keyName, file.getInputStream(), metadata));
+        }catch (IOException e){
+            log.error("error at AmazonS3Manager uploadFile : {}", (Object) e.getStackTrace());
+        }
+
+        return amazonS3.getUrl(amazonConfig.getBucket(), keyName).toString();
+    }
+}

--- a/src/main/java/com/snorlaexes/raem/global/config/AmazonConfig.java
+++ b/src/main/java/com/snorlaexes/raem/global/config/AmazonConfig.java
@@ -1,0 +1,51 @@
+package com.snorlaexes.raem.global.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import jakarta.annotation.PostConstruct;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@Getter
+public class AmazonConfig {
+    private AWSCredentials awsCredentials;
+
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @PostConstruct
+    public void init() {
+        this.awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+    }
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        AWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+
+    @Bean
+    public AWSCredentialsProvider awsCredentialsProvider() {
+        return new AWSStaticCredentialsProvider(awsCredentials);
+    }
+}
+


### PR DESCRIPTION
<!--제목: [타입] 기능명 (#이슈번호)-->

## 🔥 관련 이슈
<!-- 이 PR과 관련된 이슈 번호를 작성합니다. merge 후 issue를 닫을 예정이라면 # 앞에 close를 붙여주세요.-->
- #5 

## 작업 내용
<!--작업한 내용을 간략하게 적습니다.-->
- S3 구성 📍 관련커밋: ca4fda85
- csv 파일 저장 📍 관련커밋: ca4fda85
- csv s3 object url 조회 📍 관련커밋: ca4fda85
- 수면 데이터 정리 및 저장 📍 관련커밋: ca4fda85
- 나쁜 수면 원인 저장 📍 관련커밋: ca4fda85

## 📑 레퍼런스
<!--참고한 레퍼런스의 URL을 첨부합니다-->
- 레퍼런스1

## 🙏 요구사항
<!--테스트가 필요하거나 리뷰어들에게 요청하고 싶은 작업을 작성해주세요-->