### PR TITLE
[FEAT] 수면 분석 API 구현(with OpenAI) (#6)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,8 @@ dependencies {
 	//csv
 	implementation 'com.opencsv:opencsv:5.9'
 	//gpt
-	implementation 'io.github.flashvayne:chatgpt-spring-boot-starter:1.0.4'
+	implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.2'
+	implementation 'org.apache.httpcomponents.client5:httpclient5:5.3.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/snorlaexes/raem/domain/OpenAI/ChatGPTRequest.java
+++ b/src/main/java/com/snorlaexes/raem/domain/OpenAI/ChatGPTRequest.java
@@ -1,0 +1,19 @@
+package com.snorlaexes.raem.domain.OpenAI;
+
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+public class ChatGPTRequest {
+    private String model;
+    private List<Message> messages;
+
+    public ChatGPTRequest(String model, String prompt) {
+        this.model = model;
+        this.messages =  new ArrayList<>();
+        this.messages.add(new Message("system", "You are an expert sleep coach and data analyst. Your job is to analyze sleep data and provide users with insights about their sleep patterns and personalized recommendations for improvement. When responding, always structure your response into two sections: <Sleep Patterns> and <Improvements and Goals>. Each section should be concise and limited to 150 words or less in Korean. Your responses should be informative, supportive, and encourage healthy sleep habits."));
+        this.messages.add(new Message("user", prompt));
+    }
+}

--- a/src/main/java/com/snorlaexes/raem/domain/OpenAI/ChatGPTResponse.java
+++ b/src/main/java/com/snorlaexes/raem/domain/OpenAI/ChatGPTResponse.java
@@ -1,0 +1,24 @@
+package com.snorlaexes.raem.domain.OpenAI;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatGPTResponse {
+    private List<Choice> choices;
+
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Choice {
+        private int index;
+        private Message message;
+
+    }
+}

--- a/src/main/java/com/snorlaexes/raem/domain/OpenAI/GPTService.java
+++ b/src/main/java/com/snorlaexes/raem/domain/OpenAI/GPTService.java
@@ -1,0 +1,30 @@
+package com.snorlaexes.raem.domain.OpenAI;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+public class GPTService {
+    private static final String OPENAI_API_URL = "https://api.openai.com/v1/chat/completions";
+
+    @Value("${open-api.chat-gpt.api-key}")
+    private String apiKey;
+
+    public RestTemplate template(){
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.getInterceptors().add((request, body, execution) -> {
+            request.getHeaders().add("Authorization", "Bearer " + apiKey);
+            return execution.execute(request, body);
+        });
+        return restTemplate;
+    }
+
+    public String askChatGPT(String userMessage){
+        ChatGPTRequest request = new ChatGPTRequest("gpt-4o-2024-08-06", userMessage);
+        ChatGPTResponse chatGPTResponse =  template().postForObject(OPENAI_API_URL, request, ChatGPTResponse.class);
+        return chatGPTResponse.getChoices().get(0).getMessage().getContent();
+    }
+}

--- a/src/main/java/com/snorlaexes/raem/domain/OpenAI/Message.java
+++ b/src/main/java/com/snorlaexes/raem/domain/OpenAI/Message.java
@@ -1,0 +1,14 @@
+package com.snorlaexes.raem.domain.OpenAI;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Message {
+    private String role;
+    private String content;
+
+}

--- a/src/main/java/com/snorlaexes/raem/domain/sleep/Enums/BadAwakeReason.java
+++ b/src/main/java/com/snorlaexes/raem/domain/sleep/Enums/BadAwakeReason.java
@@ -1,5 +1,5 @@
 package com.snorlaexes.raem.domain.sleep.Enums;
 
 public enum BadAwakeReason {
-    COFFEE, EXERCISE, STRESS, ALCOHOL
+    COFFEE, EXERCISE, STRESS, ALCOHOL, SMARTPHONE
 }

--- a/src/main/java/com/snorlaexes/raem/domain/sleep/Enums/Range.java
+++ b/src/main/java/com/snorlaexes/raem/domain/sleep/Enums/Range.java
@@ -1,0 +1,5 @@
+package com.snorlaexes.raem.domain.sleep.Enums;
+
+public enum Range {
+    Weekly, Monthly
+}

--- a/src/main/java/com/snorlaexes/raem/domain/sleep/SleepController.java
+++ b/src/main/java/com/snorlaexes/raem/domain/sleep/SleepController.java
@@ -1,5 +1,6 @@
 package com.snorlaexes.raem.domain.sleep;
 
+import com.snorlaexes.raem.domain.sleep.entities.AnalysisDataEntity;
 import com.snorlaexes.raem.domain.sleep.entities.SleepDataEntity;
 import com.snorlaexes.raem.domain.sleep.entities.SleepDataUrlEntity;
 import com.snorlaexes.raem.global.apiPayload.ApiResponse;
@@ -9,7 +10,9 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.time.LocalDate;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -29,12 +32,19 @@ public class SleepController {
     }
 
     @PatchMapping("/data")
-    public ApiResponse<SleepResDTO.SaveReasonResponseDTO> saveBadReason(@RequestBody SleepReqDTO.SaveReasonDTO req) {
-        return ApiResponse.onSuccess(SleepResDTO.SaveReasonResponseDTO.saveReasonResultDTO(sleepService.saveReasonService(req)));
+    public ApiResponse<SleepResDTO.SaveReasonResponseDTO> saveBadReason(@AuthenticationPrincipal String userId, @RequestBody SleepReqDTO.SaveReasonDTO req) throws IOException {
+        SleepDataEntity saveReasonResult = sleepService.saveReasonService(req);
+        sleepService.updateAnalysisDatas(userId, saveReasonResult);
+        return ApiResponse.onSuccess(SleepResDTO.SaveReasonResponseDTO.saveReasonResultDTO(saveReasonResult));
     }
 
     @GetMapping("/data")
     public ApiResponse<SleepResDTO.GetDataUrlResponseDTO> getDataUrl(@RequestBody SleepReqDTO.GetDataUrlDTO req) {
         return ApiResponse.onSuccess(SleepResDTO.GetDataUrlResponseDTO.getDataUrlResponseDTO(sleepService.getDataUrlService(req)));
+    }
+
+    @GetMapping("/analysis")
+    public ApiResponse<List<AnalysisDataEntity>> getRangeData(@RequestParam("range") String range, @AuthenticationPrincipal String userId) {
+        return ApiResponse.onSuccess(sleepService.retrieveAnalysisData(userId, range));
     }
 }

--- a/src/main/java/com/snorlaexes/raem/domain/sleep/SleepController.java
+++ b/src/main/java/com/snorlaexes/raem/domain/sleep/SleepController.java
@@ -1,9 +1,10 @@
 package com.snorlaexes.raem.domain.sleep;
 
-import com.snorlaexes.raem.domain.sleep.entities.AnalysisDataEntity;
 import com.snorlaexes.raem.domain.sleep.entities.SleepDataEntity;
 import com.snorlaexes.raem.domain.sleep.entities.SleepDataUrlEntity;
 import com.snorlaexes.raem.global.apiPayload.ApiResponse;
+import com.snorlaexes.raem.global.apiPayload.code.status.ErrorStatus;
+import com.snorlaexes.raem.global.apiPayload.exception.ExceptionHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -12,7 +13,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.time.LocalDate;
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -43,8 +43,19 @@ public class SleepController {
         return ApiResponse.onSuccess(SleepResDTO.GetDataUrlResponseDTO.getDataUrlResponseDTO(sleepService.getDataUrlService(req)));
     }
 
-    @GetMapping("/analysis")
-    public ApiResponse<List<AnalysisDataEntity>> getRangeData(@RequestParam("range") String range, @AuthenticationPrincipal String userId) {
-        return ApiResponse.onSuccess(sleepService.retrieveAnalysisData(userId, range));
+    @GetMapping(value = "/analysis")
+    public ApiResponse<?> getRangeData(@RequestParam("range") String range, @AuthenticationPrincipal String userId) {
+        if (range.equals("weekly")) {
+            return ApiResponse.onSuccess(SleepResDTO.GetWeeklyDataDTO.getWeeklyDataDTO(sleepService.retrieveWeeklyData(userId)));
+        } else if (range.equals("monthly") || range.equals("annually")) {
+            return ApiResponse.onSuccess(SleepResDTO.GetOverMonthDataListDTO.getOverMonthDataListDTO(range, sleepService.retrieveAnalysisData(userId, range)));
+        } else {
+            throw new ExceptionHandler(ErrorStatus._WRONG_PARAM);
+        }
+    }
+
+    @GetMapping("/analysis/insight")
+    public ApiResponse<SleepResDTO.GetInsightDTO> getInsight(@AuthenticationPrincipal String userId) {
+        return ApiResponse.onSuccess(SleepResDTO.GetInsightDTO.getInsightDTO(sleepService.retrieveInsightEntity(userId)));
     }
 }

--- a/src/main/java/com/snorlaexes/raem/domain/sleep/SleepResDTO.java
+++ b/src/main/java/com/snorlaexes/raem/domain/sleep/SleepResDTO.java
@@ -1,11 +1,15 @@
 package com.snorlaexes.raem.domain.sleep;
 
-import com.snorlaexes.raem.domain.sleep.entities.LearningDataEntity;
-import com.snorlaexes.raem.domain.sleep.entities.SleepDataEntity;
-import com.snorlaexes.raem.domain.sleep.entities.SleepDataUrlEntity;
+import com.snorlaexes.raem.domain.sleep.Enums.BadAwakeReason;
+import com.snorlaexes.raem.domain.sleep.Enums.Range;
+import com.snorlaexes.raem.domain.sleep.entities.*;
 import lombok.*;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
 
 public class SleepResDTO {
 
@@ -63,6 +67,135 @@ public class SleepResDTO {
         public static GetDataUrlResponseDTO getDataUrlResponseDTO (SleepDataUrlEntity entity){
             return GetDataUrlResponseDTO.builder()
                     .url(entity.getUrl())
+                    .build();
+        }
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetWeeklyDataDTO {
+        Range type;
+        List<GetWeeklyDataListDTO> list;
+
+        public static GetWeeklyDataDTO getWeeklyDataDTO(List<SleepDataEntity> entityList) {
+            List<GetWeeklyDataListDTO> convertList = entityList.stream()
+                    .map(GetWeeklyDataListDTO::getWeeklyDataListDTO)
+                    .toList();
+
+            return GetWeeklyDataDTO.builder()
+                    .type(Range.Weekly)
+                    .list(convertList)
+                    .build();
+        }
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetWeeklyDataListDTO {
+        LocalDate sleptAt;
+        Integer score;
+        BadAwakeReason badAwakeReason;
+        LocalTime awakeTime;
+        LocalTime fellAsleepTime;
+        LocalTime sleepTime;
+        LocalTime timeOnBed;
+
+        public static GetWeeklyDataListDTO getWeeklyDataListDTO(SleepDataEntity entity) {
+            return GetWeeklyDataListDTO.builder()
+                    .sleptAt(entity.getSleptAt())
+                    .score(entity.getScore())
+                    .badAwakeReason(entity.getBadAwakeReason())
+                    .awakeTime(entity.getAwakeTime())
+                    .fellAsleepTime(entity.getFellAsleepTime())
+                    .sleepTime(entity.getSleepTime())
+                    .timeOnBed(entity.getTimeOnBed())
+                    .build();
+        }
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetOverMonthDataListDTO {
+        String type;
+        List<GetOverMonthDataDTO> dataList;
+
+        public static GetOverMonthDataListDTO getOverMonthDataListDTO(String type, List<AnalysisDataEntity> entities) {
+            List<GetOverMonthDataDTO> list = entities.stream().map(GetOverMonthDataDTO::getOverMonthDataDTO).toList();
+
+            return GetOverMonthDataListDTO.builder()
+                    .type(type)
+                    .dataList(list)
+                    .build();
+        }
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetOverMonthDataDTO {
+        String tag;
+        Integer scoreSum;
+        LocalTime inBedSum;
+        LocalTime awakeSum;
+        LocalTime sleepTimeSum;
+        List<GetReasonsListDTO> badAwakeReasonsCount;
+        Integer dataCount;
+
+        public static GetOverMonthDataDTO getOverMonthDataDTO(AnalysisDataEntity entity) {
+            List<GetReasonsListDTO> reasonsListDTOS = new ArrayList<>();
+            reasonsListDTOS.add(GetReasonsListDTO.getReasonsListDTO(BadAwakeReason.COFFEE, entity.getBadAwakeReasonsCount().get(BadAwakeReason.COFFEE)));
+            reasonsListDTOS.add(GetReasonsListDTO.getReasonsListDTO(BadAwakeReason.EXERCISE, entity.getBadAwakeReasonsCount().get(BadAwakeReason.EXERCISE)));
+            reasonsListDTOS.add(GetReasonsListDTO.getReasonsListDTO(BadAwakeReason.STRESS, entity.getBadAwakeReasonsCount().get(BadAwakeReason.STRESS)));
+            reasonsListDTOS.add(GetReasonsListDTO.getReasonsListDTO(BadAwakeReason.ALCOHOL, entity.getBadAwakeReasonsCount().get(BadAwakeReason.ALCOHOL)));
+            reasonsListDTOS.add(GetReasonsListDTO.getReasonsListDTO(BadAwakeReason.SMARTPHONE, entity.getBadAwakeReasonsCount().get(BadAwakeReason.SMARTPHONE)));
+
+            return GetOverMonthDataDTO.builder()
+                    .tag(entity.getTag())
+                    .scoreSum(entity.getScoreSum())
+                    .inBedSum(entity.getInBedSum())
+                    .awakeSum(entity.getAwakeSum())
+                    .sleepTimeSum(entity.getSleepTimeSum())
+                    .badAwakeReasonsCount(reasonsListDTOS)
+                    .dataCount(entity.getDataCount())
+                    .build();
+        }
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetReasonsListDTO {
+        BadAwakeReason reason;
+        Integer count;
+
+        public static GetReasonsListDTO getReasonsListDTO(BadAwakeReason reason, Integer count) {
+            return GetReasonsListDTO.builder()
+                    .reason(reason)
+                    .count(count)
+                    .build();
+        }
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetInsightDTO {
+        String sleepPattern;
+        String improvement;
+
+        public static GetInsightDTO getInsightDTO(InsightEntity insightEntity) {
+            return GetInsightDTO.builder()
+                    .sleepPattern(insightEntity.getSleepPattern())
+                    .improvement(insightEntity.getImprovement())
                     .build();
         }
     }

--- a/src/main/java/com/snorlaexes/raem/domain/sleep/SleepService.java
+++ b/src/main/java/com/snorlaexes/raem/domain/sleep/SleepService.java
@@ -1,34 +1,42 @@
 package com.snorlaexes.raem.domain.sleep;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.snorlaexes.raem.domain.OpenAI.GPTService;
 import com.snorlaexes.raem.domain.sleep.Enums.BadAwakeReason;
+import com.snorlaexes.raem.domain.sleep.Enums.Range;
 import com.snorlaexes.raem.domain.sleep.entities.*;
-import com.snorlaexes.raem.domain.sleep.repository.LearningDataRepository;
-import com.snorlaexes.raem.domain.sleep.repository.SleepDataRepository;
-import com.snorlaexes.raem.domain.sleep.repository.SleepDataUrlRepository;
+import com.snorlaexes.raem.domain.sleep.repository.*;
 import com.snorlaexes.raem.domain.user.UserEntity;
 import com.snorlaexes.raem.domain.user.UserRepository;
 import com.snorlaexes.raem.global.apiPayload.code.status.ErrorStatus;
 import com.snorlaexes.raem.global.apiPayload.exception.ExceptionHandler;
 import com.snorlaexes.raem.global.aws.s3.AmazonS3Manager;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.time.Duration;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.io.IOException;
+import java.time.*;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
+@Slf4j
 public class SleepService {
     private final SleepDataUrlRepository sleepDataUrlRepository;
     private final UserRepository userRepository;
     private final SleepDataRepository sleepDataRepository;
     private final AmazonS3Manager s3Manager;
     private final LearningDataRepository learningDataRepository;
+    private final AnalysisDataRepository analysisDataRepository;
+    private final InsightRepository insightRepository;
+    private final GPTService gptService;
+    private final ObjectMapper objectMapper;
 
     @Transactional
     public SleepDataUrlEntity sendS3AndSave(String userId, LocalDate sleptAt, MultipartFile file) {
@@ -75,7 +83,7 @@ public class SleepService {
         for (InBedEntity data : inBedList) {
             inBedDuration = inBedDuration.plus(Duration.between(data.getStartTime(), data.getEndTime()));
         }
-        String inBedTime = timeFormatter(inBedDuration);
+        LocalTime inBedTime = LocalTime.ofSecondOfDay(inBedDuration.getSeconds());
 
         // awake, sleep 누적 시간 계산
         Duration awakeDuration = Duration.ZERO;
@@ -87,8 +95,8 @@ public class SleepService {
                 sleepDuration = sleepDuration.plus(Duration.between(data.getStartTime(), data.getEndTime()));
             }
         }
-        String awakeTime = timeFormatter(awakeDuration);
-        String sleepTime = timeFormatter(sleepDuration);
+        LocalTime awakeTime = LocalTime.ofSecondOfDay(awakeDuration.getSeconds());
+        LocalTime sleepTime = LocalTime.ofSecondOfDay(sleepDuration.getSeconds());
 
         SleepDataEntity newSleepData = SleepDataEntity.builder()
                 .sleptAt(req.getSleptAt())
@@ -103,13 +111,6 @@ public class SleepService {
                 .build();
 
         return sleepDataRepository.save(newSleepData);
-    }
-
-    private String timeFormatter(Duration duration) {
-        long hours = duration.toHours();
-        long minutes = duration.toMinutes() % 60;
-        long seconds = duration.getSeconds() % 60;
-        return String.format("%02d:%02d:%02d", hours, minutes, seconds);
     }
 
     @Transactional
@@ -156,5 +157,199 @@ public class SleepService {
                 .build();
 
         return learningDataRepository.save(newEntity);
+    }
+
+    @Transactional
+    public void updateAnalysisDatas(String userId, SleepDataEntity sleepData) throws IOException {
+        UserEntity user = userRepository.findById(userId)
+                .orElseThrow(() -> new ExceptionHandler(ErrorStatus._USER_NOT_FOUND));
+
+        Map<String, Integer> currentWeekOfMonth = getCurrentWeekOfMonth(sleepData.getSleptAt());
+
+        //주간
+        String weeklyTag = sleepData.getSleptAt().getYear() + "_" + currentWeekOfMonth.get("Month") + "_" + currentWeekOfMonth.get("WeekNum");
+        AnalysisDataEntity weeklyData = analysisDataRepository.findByUserAndTag(user, weeklyTag);
+        if (weeklyData == null) { // 새로 추가
+            AnalysisDataEntity newData = createAnalysisData(user, weeklyTag, Range.Weekly, sleepData);
+            analysisDataRepository.save(newData);
+            log.info("Weekly successfully created!");
+        } else { // 데이터 업데이트
+            AnalysisDataEntity updatedData = updateAnalysisData(weeklyData, sleepData);
+            analysisDataRepository.save(updatedData);
+            log.info("Weekly successfully updated!");
+        }
+
+        //월간
+        String monthlyTag = sleepData.getSleptAt().getYear() + "_" + sleepData.getSleptAt().getMonthValue();
+        AnalysisDataEntity monthlyData = analysisDataRepository.findByUserAndTag(user, monthlyTag);
+        if (weeklyData == null) { // 새로 추가
+            AnalysisDataEntity newData = createAnalysisData(user, monthlyTag, Range.Monthly, sleepData);
+            analysisDataRepository.save(newData);
+            log.info("Monthly successfully created!");
+        } else { // 데이터 업데이트
+            AnalysisDataEntity updatedData = updateAnalysisData(monthlyData, sleepData);
+            analysisDataRepository.save(updatedData);
+            log.info("Monthly successfully updated!");
+        }
+
+        // GPT Query Update
+        String insightTag = String.valueOf(sleepData.getSleptAt().getYear());
+        InsightEntity insight = insightRepository.findByUserAndTag(user, insightTag);
+        List<AnalysisDataEntity> thisMonthDatas = analysisDataRepository.findByUserAndTagContaining(user, insightTag);
+        String gptQueryData = generateQueryData(thisMonthDatas);
+        String gptQueryResult = gptService.askChatGPT(gptQueryData);
+
+        String[] gptQueryResultSplit = gptQueryResult.split("\n");
+        if (insight == null) {
+            InsightEntity newInsight = InsightEntity.builder()
+                    .user(user)
+                    .tag(insightTag)
+                    .sleepPattern(gptQueryResultSplit[1])
+                    .improvement(gptQueryResultSplit[4])
+                    .createdAt(LocalDateTime.now())
+                    .updatedAt(LocalDateTime.now())
+                    .build();
+
+            insightRepository.save(newInsight);
+
+        } else {
+            insight.setSleepPattern(gptQueryResultSplit[1]);
+            insight.setImprovement(gptQueryResultSplit[4]);
+            insight.setUpdatedAt(LocalDateTime.now());
+
+            insightRepository.save(insight);
+        }
+    }
+
+    private Map<String, Integer> getCurrentWeekOfMonth(LocalDate date) {
+        // LocalDate -> Date
+        Instant dateInstant = date.atStartOfDay(ZoneId.of("Asia/Seoul")).toInstant();
+        Date formattedDate = Date.from(dateInstant);
+
+        Calendar calendar = Calendar.getInstance(Locale.KOREA);
+        calendar.setTime(formattedDate);
+        int month = calendar.get(Calendar.MONTH) + 1; // calendar에서의 월은 0부터 시작
+        int day = calendar.get(Calendar.DATE);
+
+        // 한 주의 시작은 월요일이고, 첫 주에 4일이 포함되어있어야 첫 주 취급 (목/금/토/일)
+        calendar.setFirstDayOfWeek(Calendar.MONDAY);
+        calendar.setMinimalDaysInFirstWeek(4);
+
+        int weekOfMonth = calendar.get(Calendar.WEEK_OF_MONTH);
+
+        // 첫 주에 해당하지 않는 주의 경우 전 달 마지막 주차로 계산
+        if (weekOfMonth == 0) {
+            calendar.add(Calendar.DATE, -day); // 전 달의 마지막 날 기준
+            LocalDate returnDate = calendar.getTime().toInstant().atZone(ZoneId.of("Asia/Seoul")).toLocalDate();
+            return getCurrentWeekOfMonth(returnDate);
+        }
+
+        // 마지막 주차의 경우
+        if (weekOfMonth == calendar.getActualMaximum(Calendar.WEEK_OF_MONTH)) {
+            calendar.set(Calendar.DATE, calendar.getActualMaximum(Calendar.DATE)); // 이번 달의 마지막 날
+            int lastDaysDayOfWeek = calendar.get(Calendar.DAY_OF_WEEK); // 이번 달 마지막 날의 요일
+
+            // 마지막 날이 월~수 사이이면 다음달 1주차로 계산
+            if (lastDaysDayOfWeek >= Calendar.MONDAY && lastDaysDayOfWeek <= Calendar.WEDNESDAY) {
+                calendar.add(Calendar.DATE, 1); // 마지막 날 + 1일 => 다음달 1일
+                LocalDate returnDate = calendar.getTime().toInstant().atZone(ZoneId.of("Asia/Seoul")).toLocalDate();
+                return getCurrentWeekOfMonth(returnDate);
+            }
+        }
+
+        Map<String, Integer> monthAndWeek = new HashMap<>();
+        monthAndWeek.put("Month", month);
+        monthAndWeek.put("WeekNum", weekOfMonth);
+
+        return monthAndWeek;
+    }
+
+    private AnalysisDataEntity createAnalysisData(UserEntity user, String tag, Range range, SleepDataEntity sleepData) {
+        Map<BadAwakeReason, Integer> newBadReason = new HashMap<>();
+        newBadReason.put(BadAwakeReason.COFFEE, 0);
+        newBadReason.put(BadAwakeReason.EXERCISE, 0);
+        newBadReason.put(BadAwakeReason.STRESS, 0);
+        newBadReason.put(BadAwakeReason.ALCOHOL, 0);
+        newBadReason.put(BadAwakeReason.SMARTPHONE, 0);
+        newBadReason.put(sleepData.getBadAwakeReason(), 0);
+
+        return AnalysisDataEntity.builder()
+                .user(user)
+                .dataCount(1)
+                .type(range)
+                .tag(tag)
+                .scoreSum(sleepData.getScore())
+                .awakeSum(sleepData.getAwakeTime())
+                .inBedSum(sleepData.getTimeOnBed())
+                .sleepTimeSum(sleepData.getSleepTime())
+                .badAwakeReasonsCount(newBadReason)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+    }
+
+    private AnalysisDataEntity updateAnalysisData(AnalysisDataEntity analysisData, SleepDataEntity sleepData){
+        analysisData.setDataCount(analysisData.getDataCount() + 1);
+        analysisData.setScoreSum(analysisData.getScoreSum() + sleepData.getScore());
+        analysisData.setAwakeSum(analysisData.getAwakeSum().plusSeconds(sleepData.getAwakeTime().getSecond()));
+        analysisData.setInBedSum(analysisData.getInBedSum().plusSeconds(sleepData.getTimeOnBed().getSecond()));
+        analysisData.setSleepTimeSum(analysisData.getSleepTimeSum().plusSeconds(sleepData.getSleepTime().getSecond()));
+
+        Map<BadAwakeReason, Integer> currentBadReasonsCount = analysisData.getBadAwakeReasonsCount();
+        currentBadReasonsCount.put(sleepData.getBadAwakeReason(), currentBadReasonsCount.get(sleepData.getBadAwakeReason()) + 1);
+        analysisData.setBadAwakeReasonsCount(currentBadReasonsCount);
+
+        analysisData.setUpdatedAt(LocalDateTime.now());
+        return analysisData;
+    }
+
+    private String generateQueryData(List<AnalysisDataEntity> analysisDataList) throws JsonProcessingException {
+        // 월간 데이터 정리
+        List<GPTQueryEntity> queryEntityList = analysisDataList.stream().map(data -> {
+            Duration avgAwakeTimeDuration = Duration.between(LocalTime.MIN, data.getAwakeSum()).dividedBy(data.getDataCount());
+            Duration avgInBedTimeDuration = Duration.between(LocalTime.MIN, data.getInBedSum()).dividedBy(data.getDataCount());
+            Duration avgSleepTimeDuration = Duration.between(LocalTime.MIN, data.getSleepTimeSum()).dividedBy(data.getDataCount());
+
+            StringBuilder reasonsBuilder = new StringBuilder();
+            data.getBadAwakeReasonsCount().forEach((key, value) -> {
+                if (value > data.getDataCount()) {
+                    if (!reasonsBuilder.isEmpty()) {
+                        reasonsBuilder.append(", ");
+                    }
+                    reasonsBuilder.append(key.name());
+                }
+            });
+
+            return GPTQueryEntity.builder()
+                    .yearAndMonth(data.getTag())
+                    .avgSleepScore((float) (data.getScoreSum()/data.getDataCount()))
+                    .avgAwakeTime(LocalTime.MIN.plus(avgAwakeTimeDuration))
+                    .avgInBedTime(LocalTime.MIN.plus(avgInBedTimeDuration))
+                    .avgSleepTime(LocalTime.MIN.plus(avgSleepTimeDuration))
+                    .sleepDisturbance(reasonsBuilder.toString())
+                    .build();
+
+        }).toList();
+
+        // query 생성
+        return objectMapper.writeValueAsString(queryEntityList);
+    }
+
+    public List<AnalysisDataEntity> retrieveAnalysisData(String userId, String range) {
+        UserEntity user = userRepository.findById(userId)
+                .orElseThrow(() -> new ExceptionHandler(ErrorStatus._USER_NOT_FOUND));
+        
+        ZonedDateTime requestedDateTime = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
+        String tag = "";
+        switch (range) {
+            case "week" -> {
+                Map<String, Integer> currentWeekOfMonth = getCurrentWeekOfMonth(LocalDate.from(requestedDateTime));
+                tag = requestedDateTime.getYear() + "_" + currentWeekOfMonth.get("Month") + "_" + currentWeekOfMonth.get("WeekNum");
+            }
+            case "month" -> tag = requestedDateTime.format(DateTimeFormatter.ofPattern("yyyy_MM"));
+            case "year" -> tag = requestedDateTime.format(DateTimeFormatter.ofPattern("yyyy"));
+        }
+
+        return analysisDataRepository.findByUserAndTagContaining(user, tag);
     }
 }

--- a/src/main/java/com/snorlaexes/raem/domain/sleep/entities/AnalysisDataEntity.java
+++ b/src/main/java/com/snorlaexes/raem/domain/sleep/entities/AnalysisDataEntity.java
@@ -1,6 +1,7 @@
 package com.snorlaexes.raem.domain.sleep.entities;
 
 import com.snorlaexes.raem.domain.sleep.Enums.BadAwakeReason;
+import com.snorlaexes.raem.domain.sleep.Enums.Range;
 import com.snorlaexes.raem.domain.user.UserEntity;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,31 +12,33 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.mongodb.core.mapping.DBRef;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.Map;
 
 @Getter
 @Setter
 @Builder
-@Document(collection = "SleepData")
-public class SleepDataEntity {
+@Document(collection = "AnalysisData")
+public class AnalysisDataEntity {
     @Id
     String id;
-    LocalDate sleptAt;
-    Integer score;
-    BadAwakeReason badAwakeReason;
 
-    LocalTime awakeTime;
-    LocalTime fellAsleepTime;
-    LocalTime sleepTime;
-    LocalTime timeOnBed;
+    Range type;
+    String tag;
+
+    Integer scoreSum;
+    LocalTime inBedSum;
+    LocalTime awakeSum;
+    LocalTime sleepTimeSum;
+    Map<BadAwakeReason, Integer> badAwakeReasonsCount;
+    Integer dataCount;
+
+    @DBRef
+    UserEntity user;
 
     @CreatedDate
     LocalDateTime createdAt;
     @LastModifiedDate
     LocalDateTime updatedAt;
-
-    @DBRef
-    private UserEntity user;
 }

--- a/src/main/java/com/snorlaexes/raem/domain/sleep/entities/GPTQueryEntity.java
+++ b/src/main/java/com/snorlaexes/raem/domain/sleep/entities/GPTQueryEntity.java
@@ -1,0 +1,19 @@
+package com.snorlaexes.raem.domain.sleep.entities;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalTime;
+
+@Getter
+@Setter
+@Builder
+public class GPTQueryEntity {
+    String yearAndMonth;
+    Float avgSleepScore;
+    LocalTime avgAwakeTime;
+    LocalTime avgInBedTime;
+    LocalTime avgSleepTime;
+    String sleepDisturbance;
+}

--- a/src/main/java/com/snorlaexes/raem/domain/sleep/entities/InsightEntity.java
+++ b/src/main/java/com/snorlaexes/raem/domain/sleep/entities/InsightEntity.java
@@ -1,6 +1,5 @@
 package com.snorlaexes.raem.domain.sleep.entities;
 
-import com.snorlaexes.raem.domain.sleep.Enums.BadAwakeReason;
 import com.snorlaexes.raem.domain.user.UserEntity;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,31 +10,25 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.mongodb.core.mapping.DBRef;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 
 @Getter
 @Setter
 @Builder
-@Document(collection = "SleepData")
-public class SleepDataEntity {
+@Document(collection = "Insights")
+public class InsightEntity {
     @Id
     String id;
-    LocalDate sleptAt;
-    Integer score;
-    BadAwakeReason badAwakeReason;
+    String tag;
 
-    LocalTime awakeTime;
-    LocalTime fellAsleepTime;
-    LocalTime sleepTime;
-    LocalTime timeOnBed;
+    String sleepPattern;
+    String improvement;
+
+    @DBRef
+    UserEntity user;
 
     @CreatedDate
     LocalDateTime createdAt;
     @LastModifiedDate
     LocalDateTime updatedAt;
-
-    @DBRef
-    private UserEntity user;
 }

--- a/src/main/java/com/snorlaexes/raem/domain/sleep/repository/AnalysisDataRepository.java
+++ b/src/main/java/com/snorlaexes/raem/domain/sleep/repository/AnalysisDataRepository.java
@@ -1,0 +1,12 @@
+package com.snorlaexes.raem.domain.sleep.repository;
+
+import com.snorlaexes.raem.domain.sleep.entities.AnalysisDataEntity;
+import com.snorlaexes.raem.domain.user.UserEntity;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.List;
+
+public interface AnalysisDataRepository extends MongoRepository<AnalysisDataEntity, String> {
+    AnalysisDataEntity findByUserAndTag(UserEntity user, String tag);
+    List<AnalysisDataEntity> findByUserAndTagContaining(UserEntity user, String tagPart);
+}

--- a/src/main/java/com/snorlaexes/raem/domain/sleep/repository/AnalysisDataRepository.java
+++ b/src/main/java/com/snorlaexes/raem/domain/sleep/repository/AnalysisDataRepository.java
@@ -1,5 +1,6 @@
 package com.snorlaexes.raem.domain.sleep.repository;
 
+import com.snorlaexes.raem.domain.sleep.Enums.Range;
 import com.snorlaexes.raem.domain.sleep.entities.AnalysisDataEntity;
 import com.snorlaexes.raem.domain.user.UserEntity;
 import org.springframework.data.mongodb.repository.MongoRepository;
@@ -9,4 +10,5 @@ import java.util.List;
 public interface AnalysisDataRepository extends MongoRepository<AnalysisDataEntity, String> {
     AnalysisDataEntity findByUserAndTag(UserEntity user, String tag);
     List<AnalysisDataEntity> findByUserAndTagContaining(UserEntity user, String tagPart);
+    List<AnalysisDataEntity> findAllByUserAndTypeAndTagContaining(UserEntity user, Range range, String tagPart);
 }

--- a/src/main/java/com/snorlaexes/raem/domain/sleep/repository/InsightRepository.java
+++ b/src/main/java/com/snorlaexes/raem/domain/sleep/repository/InsightRepository.java
@@ -1,0 +1,9 @@
+package com.snorlaexes.raem.domain.sleep.repository;
+
+import com.snorlaexes.raem.domain.sleep.entities.InsightEntity;
+import com.snorlaexes.raem.domain.user.UserEntity;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface InsightRepository extends MongoRepository<InsightEntity, String> {
+    InsightEntity findByUserAndTag(UserEntity user, String tag);
+}

--- a/src/main/java/com/snorlaexes/raem/domain/sleep/repository/SleepDataRepository.java
+++ b/src/main/java/com/snorlaexes/raem/domain/sleep/repository/SleepDataRepository.java
@@ -4,9 +4,9 @@ import com.snorlaexes.raem.domain.sleep.entities.SleepDataEntity;
 import com.snorlaexes.raem.domain.user.UserEntity;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
-import java.util.Date;
-import java.util.Optional;
+import java.time.LocalDate;
+import java.util.List;
 
 public interface SleepDataRepository extends MongoRepository<SleepDataEntity, String> {
-    Optional<SleepDataEntity> findBySleptAtAndUser(Date date, UserEntity user);
+    List<SleepDataEntity> findAllByUserAndSleptAtBetween(UserEntity user, LocalDate first, LocalDate last);
 }


### PR DESCRIPTION
<!--제목: [타입] 기능명 (#이슈번호)-->

## 🔥 관련 이슈
<!-- 이 PR과 관련된 이슈 번호를 작성합니다. merge 후 issue를 닫을 예정이라면 # 앞에 close를 붙여주세요.-->
- #6 

## 작업 내용
<!--작업한 내용을 간략하게 적습니다.-->
- 분석용 수면 데이터 저장 로직 📍 관련커밋: 8ddbde91
- ChatGPT 질의 및 응답 로직 📍 관련커밋: 8ddbde91
- 분석 데이터 조회 api 📍 관련커밋: 8ddbde91
- GPT 분석 데이터 조회 api 📍 관련커밋: 8ddbde91

## 📑 레퍼런스
<!--참고한 레퍼런스의 URL을 첨부합니다-->
- [ChatGPT](https://velog.io/@yunh03/Spring-Boot%EC%97%90%EC%84%9C-ChatGPT-%ED%99%9C%EC%9A%A9%ED%95%98%EA%B8%B0-1-API-%EC%97%B0%EA%B2%B0-%ED%85%8C%EC%8A%A4%ED%8A%B8)

## 🙏 요구사항
<!--테스트가 필요하거나 리뷰어들에게 요청하고 싶은 작업을 작성해주세요-->